### PR TITLE
Chore/module-ize Utils

### DIFF
--- a/lib/git_transactor.rb
+++ b/lib/git_transactor.rb
@@ -1,5 +1,5 @@
 require 'git_transactor/version'
+require 'git_transactor/utils'
 require 'git_transactor/processor'
 require 'git_transactor/queue_entry'
 require 'git_transactor/queue_manager'
-require 'git_transactor/utils'

--- a/lib/git_transactor/processor.rb
+++ b/lib/git_transactor/processor.rb
@@ -4,6 +4,8 @@ module GitTransactor
   ##
   # This class processes GitTransactor queue entries
   class Processor
+    include Utils
+
     def initialize(params)
       @params = params
       check_params!
@@ -145,7 +147,7 @@ private
     #         a/b/c.xml
     #
     def file_rel_path
-      Utils.source_path_to_repo_path(@qe.path)
+      source_path_to_repo_path(@qe.path)
     end
 
     def dir_rel_path

--- a/lib/git_transactor/utils.rb
+++ b/lib/git_transactor/utils.rb
@@ -1,8 +1,11 @@
 module GitTransactor
   ##
   # contains Git Transactor utility methods
-  class Utils
-    def self.source_path_to_repo_path(path)
+  module Utils
+
+private
+
+    def source_path_to_repo_path(path)
       # current repo structure is <repo root>/<dir>/<file>
       File.absolute_path(path).split(File::SEPARATOR)[-2..-1]
         .join(File::SEPARATOR)

--- a/spec/git_transactor/utils_spec.rb
+++ b/spec/git_transactor/utils_spec.rb
@@ -7,8 +7,10 @@ module GitTransactor
     let(:source_file_path) { '/a/b/c/d/foo.xml' }
 
     describe '.source_path_to_repo_path' do
+      let(:dummy_class) { Class.new { include Utils } }
+      let(:o) { dummy_class.new }
       it "should perform the correct conversion" do
-        expect(Utils.source_path_to_repo_path(source_file_path)).to be == repo_file_path
+        expect(o.send(:source_path_to_repo_path, source_file_path)).to be == repo_file_path
       end
     end
   end


### PR DESCRIPTION
## Highlights
* convert `GitTransactor::Utils` from `class` into a `module`
* update testing and usage of `GitTransactor::Utils` as needed