### PR TITLE
Feature/add rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,27 +2,56 @@ require "bundler/gem_tasks"
 require_relative "lib/git_transactor"
 
 namespace :git_transactor do
+
   namespace :setup do
     desc "Initialize queue structure in QUEUE_ROOT directory"
     task :queue do
       GitTransactor::QueueManager.create(ENV["QUEUE_ROOT"])
     end
   end
+
   desc "Process entries in queue and push to remote"
   task :process_and_push do
-    gt = GitTransactor::Processor.new(repo_path:   ENV["LOCAL_REPO"],
-                                      source_path: ENV["SOURCE_PATH"],
-                                      work_root:   ENV["QUEUE_ROOT"],
-                                      remote_url:  ENV["REMOTE_REPO_URL"])
+    process
+    push
+  end
+
+  desc "Pull from remote repository to local repository"
+  task :pull do
+    pull
+  end
+
+  desc "Push from local repository to remote repository"
+  task :push do
+    push
+  end
+
+  desc "Pull from remote repository, process queue, and push back to remote repository"
+  task :pull_process_push do
+    pull
+    process
+    push
+  end
+
+  #----------------------------------------------------------------------------
+  # methods
+
+  def gt
+    @gt ||= GitTransactor::Processor.new(repo_path:   ENV["LOCAL_REPO"],
+                                         source_path: ENV["SOURCE_PATH"],
+                                         work_root:   ENV["QUEUE_ROOT"],
+                                         remote_url:  ENV["REMOTE_REPO_URL"])
+  end
+
+  def process
     gt.process_queue
+  end
+
+  def push
     gt.push
   end
-  desc "Pull from remote repo to local repo"
-  task :pull do
-    gt = GitTransactor::Processor.new(repo_path:   ENV["LOCAL_REPO"],
-                                      source_path: ENV["SOURCE_PATH"],
-                                      work_root:   ENV["QUEUE_ROOT"],
-                                      remote_url:  ENV["REMOTE_REPO_URL"])
+
+  def pull
     gt.pull
   end
 end

--- a/features/rake_pull_process_push.feature
+++ b/features/rake_pull_process_push.feature
@@ -1,0 +1,31 @@
+Feature: pull from remote repo, process queue, and push using a Rake task
+
+  As a User
+  I want to use a Rake task to
+    update the local repository using a pull operation then
+    process the queue and
+    push any changes back to the remote repository
+  So that all additions and deletions are
+    applied to a current version of the repository
+    and are reflected in the remote repository
+
+  Scenario: process queue and push using Rake task
+    Given that the remote repository exists
+    And   that the local repository exists and was cloned from the remote repository
+    And   the remote repository has changes that the local repository does not
+    And   that a queue parent directory exists
+    And   the request queue exists
+    And   a source-file directory exists
+    And   a source-file named "foo/bar.txt" exists
+    And   a source-file named "baz/quux.txt" exists
+    And   the file "circle/square.txt" exists in the repository
+    And   the file "triangle/rhombus.txt" exists in the repository
+    And   there is an "add" request for "foo/bar.txt" in the queue
+    And   there is an "rm" request for "circle/square.txt" in the queue
+    And   there is an "add" request for "baz/quux.txt" in the queue
+    And   there is an "rm" request for "triangle/rhombus.txt" in the queue
+    When  I execute the pull, process, and push Rake task
+    Then  I should see "foo/bar.txt" in the repository
+    And   I should see "baz/quux.txt" in the repository
+    And   I should see "Updating file foo/bar.txt, Deleting file circle/square.txt, Updating file baz/quux.txt, Deleting file triangle/rhombus.txt" in the commit log
+    And   the local repository and the remote repository should be in the same state

--- a/features/step_definitions/rake_pull_process_push_steps.rb
+++ b/features/step_definitions/rake_pull_process_push_steps.rb
@@ -1,0 +1,5 @@
+require 'open3'
+When(/^I execute the pull, process, and push Rake task$/) do
+  _, e, s = Open3.capture3("rake git_transactor:pull_process_push LOCAL_REPO='#{@repo_path}' SOURCE_PATH='#{@src_dir.path}' QUEUE_ROOT='#{@work_root}' REMOTE_REPO_URL='#{@remote_repo_path}'")
+  raise RuntimeError.new(e)unless s == 0
+end

--- a/spec/git_transactor/queue_manager_spec.rb
+++ b/spec/git_transactor/queue_manager_spec.rb
@@ -157,56 +157,58 @@ module GitTransactor
     end
 
 
-    describe "#lock!" do
+    describe "lock-related methods" do
       before(:each) { setup_valid_state }
-      let (:qm) { GitTransactor::QueueManager.open(valid_root) }
+      after(:each)  { teardown_valid_state }
 
-      context "when the queue manager is unlocked" do
-        it "should not raise an exception" do
-          expect { qm.lock! }.to_not raise_error
+      describe "#lock!" do
+        let (:qm) { GitTransactor::QueueManager.open(valid_root) }
+
+        context "when the queue manager is unlocked" do
+          it "should not raise an exception" do
+            expect { qm.lock! }.to_not raise_error
+          end
+        end
+
+        context "when the queue manager is locked" do
+          it "should raise an exception" do
+            qm.lock!
+            expect { qm.lock! }.to raise_error(LockError)
+          end
         end
       end
 
-      context "when the queue manager is locked" do
-        it "should raise an exception" do
-          qm.lock!
-          expect { qm.lock! }.to raise_error(LockError)
+      describe "#locked?" do
+        let (:qm) { GitTransactor::QueueManager.open(valid_root) }
+
+        context "when the queue manager is unlocked" do
+          it "should return false" do
+            expect(qm).to_not be_locked
+          end
         end
-      end
-    end
 
-    describe "#locked?" do
-      before(:each) { setup_valid_state }
-      let (:qm) { GitTransactor::QueueManager.open(valid_root) }
-
-      context "when the queue manager is unlocked" do
-        it "should return false" do
-          expect(qm).to_not be_locked
-        end
-      end
-
-      context "when the queue manager is locked" do
-        it "should return true" do
-          qm.lock!
-          expect(qm).to be_locked
-        end
-      end
-    end
-
-    describe "#unlock" do
-      before(:each) { setup_valid_state }
-      let (:qm) { GitTransactor::QueueManager.open(valid_root) }
-
-      context "when the queue manager is unlocked" do
-        it "should remain unlocked" do
-          expect { qm.unlock }.not_to change{qm.locked?}
+        context "when the queue manager is locked" do
+          it "should return true" do
+            qm.lock!
+            expect(qm).to be_locked
+          end
         end
       end
 
-      context "when the queue manager is locked" do
-        it "should unlock the queue" do
-          qm.lock!
-          expect { qm.unlock }.to change{qm.locked?}.from(true).to(false)
+      describe "#unlock" do
+        let (:qm) { GitTransactor::QueueManager.open(valid_root) }
+
+        context "when the queue manager is unlocked" do
+          it "should remain unlocked" do
+            expect { qm.unlock }.not_to change{qm.locked?}
+          end
+        end
+
+        context "when the queue manager is locked" do
+          it "should unlock the queue" do
+            qm.lock!
+            expect { qm.unlock }.to change{qm.locked?}.from(true).to(false)
+          end
         end
       end
     end

--- a/spec/support/setup/queue_manager.rb
+++ b/spec/support/setup/queue_manager.rb
@@ -6,6 +6,10 @@ module GitTransactor
         tq.nuke
         tq.init
       end
+      def teardown_valid_state
+        tq = TestQueue.new(valid_root)
+        tq.nuke
+      end
       def setup_unreadable_root
         tq = TestQueue.new(unreadable_root)
         tq.nuke


### PR DESCRIPTION
## Highlights
* add `rake` task `pull_process_push` so that local repo is brought into line with remote before applying local changes
* add discrete `pull`, `push`, and `process` `rake` tasks 
* add methods to `Rakefile` to DRY up code
* add teardown to lock-related `QueueManager` examples
* DRY up `QueueManager` examples by adding an outer "lock-related methods" `describe` block and moving setup and teardown calls to outer block
